### PR TITLE
Use context manager when parsing PDFs

### DIFF
--- a/extractors/pdf_parser.py
+++ b/extractors/pdf_parser.py
@@ -55,8 +55,9 @@ def extract_text_from_pdf(pdf_bytes: bytes) -> str:
     -----
     This purposely ignores images and tables—LLMs cope fine with raw text.
     """
-    doc = fitz.open(stream=pdf_bytes, filetype="pdf")
-    full_text = "\n".join(page.get_text() for page in doc)
+    with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
+        full_text = "\n".join(page.get_text() for page in doc)
+
     return full_text
 
 


### PR DESCRIPTION
## Summary
- ensure PDFs are opened with a `with` block so files close automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a131305c8330b676a74f3ecef74e