### PR TITLE
Improve docs on lazy imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@ from dotenv import load_dotenv
 import os
 import streamlit as st
 import pandas as pd
-from io import StringIO
 import base64
 from openai import AzureOpenAI
 from extractors.json_extractor import extract_json


### PR DESCRIPTION
## Summary
- clarify lazy import strategy in pdf parser docs
- move heavy imports inside functions and add TYPE_CHECKING block
- remove unused import in app

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a13495ec83308e2a7d03ac950535